### PR TITLE
Cargo fmt & Clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "A library to help with live-reloading game development"
 license = "Zlib"
 documentation = "https://docs.rs/live-reloading"
 repository = "https://github.com/porglezomp-misc/live-reloading-rs"
+edition = "2018"
 
 [dependencies]
 libloading = "0.4"

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -18,8 +18,8 @@ fn print(msg: &str) {
 }
 
 fn main() {
-    let mut app = App::new("target/debug/libreloadable.dylib", Host { print: print })
-        .expect("Should load!");
+    let mut app =
+        App::new("target/debug/libreloadable.dylib", Host { print }).expect("Should load!");
     loop {
         if app.update() == ShouldQuit::Yes {
             break;


### PR DESCRIPTION
Hello @porglezomp , 

thank you for this wonderful library. It gives me a great head start for a project I am developing.

And becuase I am planning to use this library in _source form_ and I've enabled clippy in the IDE, rust-analyzer was constantly complaining. This PR fixes them, updates the Rust edition and also uses `cargo fmt` for formatting.