### PR TITLE
"Safer" State

### DIFF
--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -21,9 +21,9 @@ struct State {
     counter: usize,
 }
 
-fn init(host: &mut Host, state: &mut State) {
-    state.counter = 0;
+fn init(host: &mut Host) -> State {
     (host.print)("Init! Counter: 0.\n");
+    State { counter: 0 }
 }
 
 fn reload(host: &mut Host, state: &mut State) {
@@ -40,7 +40,7 @@ fn unload(host: &mut Host, state: &mut State) {
     (host.print)(&format!("Unloaded at {}.\n", state.counter));
 }
 
-fn deinit(host: &mut Host, state: &mut State) {
+fn deinit(host: &mut Host, state: State) {
     (host.print)(&format!(
         "Goodbye! Reached a final value of {}.\n",
         state.counter


### PR DESCRIPTION
`State` is unsafe in respect to hot reloading new versions of the dynamic library that is being watched, but it does not have to unsafe when initialized or dropped. With this PR merged, `State` can be initialized by returning it from the `init()` function and dropped (implicitly) in the `deinit()` function.

Context was that I never was sure what kind of values were safe to put into State, sometimes putting another complex Rust value worked, and sometimes an `Option<Box<T>>` was needed to avoid crashes at initialization time.